### PR TITLE
duchamp: Enable CameraX extensions support

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -8,6 +8,7 @@ MIUICAMERA_PATH := device/xiaomi/duchamp-miuicamera
 
 # Properties
 TARGET_SYSTEM_PROP += $(MIUICAMERA_PATH)/system.prop
+TARGET_ODM_PROP += $(MIUICAMERA_PATH)/odm.prop
 
 # SELinux
 BOARD_VENDOR_SEPOLICY_DIRS += $(MIUICAMERA_PATH)/sepolicy/vendor

--- a/configs/permissions/camerax-vendor-extensions.xml
+++ b/configs/permissions/camerax-vendor-extensions.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+ <permissions>
+     <library name="camerax-vendor-extensions.jar"
+         file="/system_ext/framework/camerax-vendor-extensions.jar" />
+ </permissions>

--- a/device.mk
+++ b/device.mk
@@ -20,5 +20,9 @@ PRODUCT_COPY_FILES += \
 PRODUCT_SOONG_NAMESPACES += \
     $(LOCAL_PATH)
 
+# CameraExtensions
+PRODUCT_COPY_FILES += \
+    $(LOCAL_PATH)/configs/permissions/camerax-vendor-extensions.xml:$(TARGET_COPY_OUT_SYSTEM_EXT)/etc/permissions/camerax-vendor-extensions.xml
+
 # Inherit from the proprietary version
 $(call inherit-product, vendor/xiaomi/duchamp-miuicamera/duchamp-miuicamera-vendor.mk)

--- a/extract-files.sh
+++ b/extract-files.sh
@@ -54,7 +54,6 @@ fi
 function blob_fixup() {
     case "${1}" in
         system_ext/priv-app/MiuiCamera/MiuiCamera.apk)
-            # Replace Miui Gallery with Google Photos
             tmp_dir="${EXTRACT_TMP_DIR}/MiuiCamera"
             apktool d -q "$2" -o "$tmp_dir" -f
             grep -rl "com.miui.gallery" "$tmp_dir" | xargs sed -i 's|com\.miui\.gallery|com\.google\.android\.apps\.photos|g'

--- a/odm.prop
+++ b/odm.prop
@@ -1,0 +1,2 @@
+# Camera
+ro.camerax.extensions.enabled=true

--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -7,3 +7,4 @@ system_ext/lib64/libcamera_ispinterface_jni.xiaomi.so
 system_ext/lib64/libmtkisp_metadata_sys.so
 system_ext/lib64/vendor.mediatek.hardware.camera.isphal@1.0.so;MODULE_SUFFIX=-system_ext
 system_ext/lib64/vendor.mediatek.hardware.camera.isphal-V1-ndk.so;MODULE_SUFFIX=-system_ext
+system_ext/framework/camerax-vendor-extensions.jar

--- a/system.prop
+++ b/system.prop
@@ -1,3 +1,7 @@
+# Camera
+ro.camerax.extensions.enabled=true
+
+# Miui Camera
 persist.vendor.camera.privapp.list=com.android.camera
 ro.com.google.lens.oem_camera_package=com.android.camera
 ro.product.mod_device=duchamp_global


### PR DESCRIPTION
- Set `ro.camerax.extensions.enabled=true` in both system.prop and odm.prop
- Add `camerax-vendor-extensions.jar` to system_ext
- Grant required permission via `camerax-vendor-extensions.xml`

Enables support for enhanced camera features via CameraX Extensions, improving compatibility with modern camera apps.